### PR TITLE
I18n localization

### DIFF
--- a/languages/pmpro-add-name-to-checkout.pot
+++ b/languages/pmpro-add-name-to-checkout.pot
@@ -1,0 +1,68 @@
+#, fuzzy
+msgid ""
+msgstr ""
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+"Project-Id-Version: Paid Memberships Pro - Add Name to Checkout Add On\n"
+"POT-Creation-Date: 2019-06-25 18:10+0200\n"
+"PO-Revision-Date: 2019-06-25 11:15+0200\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.2\n"
+"X-Poedit-Basepath: ..\n"
+"X-Poedit-Flags-xgettext: --add-comments=translators:\n"
+"X-Poedit-WPHeader: pmpro-add-name-to-checkout.php\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+"X-Poedit-KeywordsList: __;_e;_n:1,2;_x:1,2c;_ex:1,2c;_nx:4c,1,2;esc_attr__;"
+"esc_attr_e;esc_attr_x:1,2c;esc_html__;esc_html_e;esc_html_x:1,2c;"
+"_n_noop:1,2;_nx_noop:3c,1,2;__ngettext_noop:1,2\n"
+"X-Poedit-SearchPath-0: .\n"
+"X-Poedit-SearchPathExcluded-0: *.js\n"
+
+#: pmpro-add-name-to-checkout.php:50
+msgid "First Name"
+msgstr ""
+
+#: pmpro-add-name-to-checkout.php:54
+msgid "Last Name"
+msgstr ""
+
+#: pmpro-add-name-to-checkout.php:74
+msgid "Account Information"
+msgstr ""
+
+#: pmpro-add-name-to-checkout.php:113
+msgid "The first and last name fields are required."
+msgstr ""
+
+#: pmpro-add-name-to-checkout.php:173
+msgid "Visit Customer Support Forum"
+msgstr ""
+
+#: pmpro-add-name-to-checkout.php:173
+msgid "Support"
+msgstr ""
+
+#. Plugin Name of the plugin/theme
+msgid "Paid Memberships Pro - Add Name to Checkout Add On"
+msgstr ""
+
+#. Plugin URI of the plugin/theme
+msgid "http://www.paidmembershipspro.com/wp/pmpro-add-name-to-checkout/"
+msgstr ""
+
+#. Description of the plugin/theme
+msgid ""
+"Adds first and last name fields to the user account section at checkout for "
+"Paid Memberships Pro."
+msgstr ""
+
+#. Author of the plugin/theme
+msgid "Stranger Studios"
+msgstr ""
+
+#. Author URI of the plugin/theme
+msgid "http://www.strangerstudios.com"
+msgstr ""

--- a/pmpro-add-name-to-checkout.php
+++ b/pmpro-add-name-to-checkout.php
@@ -19,7 +19,7 @@ Domain Path: /languages
 function pmproan2c_load_plugin_text_domain() {
 	load_plugin_textdomain( 'pmpro-add-name-to-checkout', false, basename( dirname( __FILE__ ) ) . '/languages' ); 
 }
-add_action( 'plugins_loaded', 'pmproan2c_load_plugin_text_domain' ); 
+add_action( 'init', 'pmproan2c_load_plugin_text_domain' ); 
 
 /**
  * Add the fields to the form.

--- a/pmpro-add-name-to-checkout.php
+++ b/pmpro-add-name-to-checkout.php
@@ -8,7 +8,18 @@ Text Domain: pmpro-add-name-to-checkout
 Domain Path: /languages
 Author: Stranger Studios
 Author URI: http://www.strangerstudios.com
+Text Domain: pmpro-add-name-to-checkout
+Domain Path: /languages
 */
+
+/**
+ * Load text domain
+ * pmproan2c_load_plugin_text_domain
+ */
+function pmproan2c_load_plugin_text_domain() {
+	load_plugin_textdomain( 'pmpro-add-name-to-checkout', false, basename( dirname( __FILE__ ) ) . '/languages' ); 
+}
+add_action( 'plugins_loaded', 'pmproan2c_load_plugin_text_domain' ); 
 
 /**
  * Add the fields to the form.
@@ -37,11 +48,11 @@ function pmproan2c_pmpro_checkout_after_password() {
 	}
 	?>
 	<div class="pmpro_checkout-field pmpro_checkout-field-firstname">
-		<label for="first_name"><?php _e( 'First Name', 'pmpro' ); ?></label>
+		<label for="first_name"><?php _e( 'First Name', 'paid-memberships-pro' ); ?></label>
 		<input id="first_name" name="first_name" type="text" class="input pmpro_required <?php echo pmpro_getClassForField( 'first_name' ); ?>" size="30" value="<?php echo esc_attr( $first_name ); ?>" />
 	</div>
 	<div class="pmpro_checkout-field pmpro_checkout-field-lastname">
-		<label for="last_name"><?php _e( 'Last Name', 'pmpro' ); ?></label>
+		<label for="last_name"><?php _e( 'Last Name', 'paid-memberships-pro' ); ?></label>
 		<input id="last_name" name="last_name" type="text" class="input pmpro_required <?php echo pmpro_getClassForField( 'last_name' ); ?>" size="30" value="<?php echo esc_attr( $last_name ); ?>" />
 	</div> 
 	<?php
@@ -160,7 +171,7 @@ add_action( 'pmpro_before_send_to_twocheckout', 'pmproan2c_pmpro_paypalexpress_s
 function pmproan2c_plugin_row_meta( $links, $file ) {
 	if ( strpos( $file, 'pmpro-add-name-to-checkout.php' ) !== false ) {
 		$new_links = array(
-			'<a href="' . esc_url( 'https://www.paidmembershipspro.com/support/' ) . '" title="' . esc_attr( __( 'Visit Customer Support Forum', 'pmpro-add-name-to-checkout' ) ) . '">' . __( 'Support', 'pmpro-add-name-to-checkout' ) . '</a>',
+			'<a href="' . esc_url( 'https://www.paidmembershipspro.com/support/' ) . '" title="' . esc_attr( __( 'Visit Customer Support Forum', 'paid-memberships-pro' ) ) . '">' . __( 'Support', 'paid-memberships-pro' ) . '</a>',
 		);
 		$links     = array_merge( $links, $new_links );
 	}

--- a/pmpro-add-name-to-checkout.php
+++ b/pmpro-add-name-to-checkout.php
@@ -72,7 +72,7 @@ function pmproan2c_account_info_when_logged_in() {
 	<hr />
 	<div id="pmpro_user_fields" class="pmpro_checkout">
 		<h3>
-			<span class="pmpro_checkout-h3-name"><?php _e('Account Information', 'pmpro-add-name-to-checkout' );?></span>			
+			<span class="pmpro_checkout-h3-name"><?php _e('Account Information', 'paid-memberships-pro' );?></span>			
 		</h3>
 		<div class="pmpro_checkout-fields">
 			<?php pmproan2c_pmpro_checkout_after_password(); ?>


### PR DESCRIPTION
As this is a simple extension on the core plugin all text strings, except [1 unique string](https://github.com/ipokkel/pmpro-add-name-to-checkout/blob/a62a89b47931ac0d1c8f704f67f8276655076a40/pmpro-add-name-to-checkout.php#L114) for this plugin, piggybacks on the core text domain for translation strings.

- add text domain `pmpro-add-name-to-checkout`
- add folder `languages`
- add function pmproan2c_load_plugin_text_domain
- change text domain `pmpro` to `paid-memberships-pro`
- create pmpro-add-name-to-checkout.pot