### PR TITLE
Require first and last name for logged in users

### DIFF
--- a/pmpro-add-name-to-checkout.php
+++ b/pmpro-add-name-to-checkout.php
@@ -96,7 +96,7 @@ function pmproan2c_pmpro_registration_checks() {
 		$last_name = '';
 	}
 
-	if ( $first_name && $last_name || $current_user->ID ) {
+	if ( $first_name && $last_name ) {
 		//all good
 		return true;
 	} else {

--- a/pmpro-add-name-to-checkout.php
+++ b/pmpro-add-name-to-checkout.php
@@ -15,7 +15,7 @@ Author URI: http://www.strangerstudios.com
  */
 function pmproan2c_pmpro_checkout_after_password() {
 	global $current_user;
-	
+
 	if ( ! empty( $_REQUEST['first_name'] ) ) {
 		$first_name = sanitize_text_field( $_REQUEST['first_name'] );
 	} elseif ( ! empty( $_SESSION['first_name'] ) ) {
@@ -53,15 +53,15 @@ add_action( 'pmpro_checkout_after_password', 'pmproan2c_pmpro_checkout_after_pas
  */
 function pmproan2c_account_info_when_logged_in() {
 	global $current_user;
-	
+
 	if ( ! is_user_logged_in() ) {
 		return;
-	}	
+	}
 	?>
 	<hr />
 	<div id="pmpro_user_fields" class="pmpro_checkout">
 		<h3>
-			<span class="pmpro_checkout-h3-name"><?php _e('Account Information', 'pmpro-add-name-to-checkout' );?></span>			
+			<span class="pmpro_checkout-h3-name"><?php _e( 'Account Information', 'pmpro-add-name-to-checkout' ); ?></span>
 		</h3>
 		<div class="pmpro_checkout-fields">
 			<?php pmproan2c_pmpro_checkout_after_password(); ?>


### PR DESCRIPTION
- WPCS: Tidy up spacing and empty blank tabs at line endings.
- Remove the argument in if statement passing a true for logged in users irrespective whether we have a first and last name for them.