### PR TITLE
Make first/last name optional with filters.

### DIFF
--- a/pmpro-add-name-to-checkout.php
+++ b/pmpro-add-name-to-checkout.php
@@ -15,6 +15,24 @@ Author URI: http://www.strangerstudios.com
  */
 function pmproan2c_pmpro_checkout_after_password() {
 	global $current_user;
+
+	/**
+	 * Allow others to make the first name required or not.
+	 *
+	 * @since 0.5
+	 *
+	 * @param bool `true` for required, `false` if not.
+	 */
+	$first_name_required = apply_filters( 'pmproan2c_first_name_required', true );
+
+	/**
+	 * Allow others to make the last name required or not.
+	 *
+	 * @since 0.5
+	 *
+	 * @param bool `true` for required, `false` if not.
+	 */
+	$last_name_required = apply_filters( 'pmproan2c_last_name_required', true );
 	
 	if ( ! empty( $_REQUEST['first_name'] ) ) {
 		$first_name = sanitize_text_field( $_REQUEST['first_name'] );
@@ -38,11 +56,11 @@ function pmproan2c_pmpro_checkout_after_password() {
 	?>
 	<div class="pmpro_checkout-field pmpro_checkout-field-firstname">
 		<label for="first_name"><?php _e( 'First Name', 'pmpro' ); ?></label>
-		<input id="first_name" name="first_name" type="text" class="input pmpro_required <?php echo pmpro_getClassForField( 'first_name' ); ?>" size="30" value="<?php echo esc_attr( $first_name ); ?>" />
+		<input id="first_name" name="first_name" type="text" class="input <?php echo $first_name_required ? esc_attr( 'pmpro_required' ) : ''; ?> <?php echo pmpro_getClassForField( 'first_name' ); ?>" size="30" value="<?php echo esc_attr( $first_name ); ?>" />
 	</div>
 	<div class="pmpro_checkout-field pmpro_checkout-field-lastname">
 		<label for="last_name"><?php _e( 'Last Name', 'pmpro' ); ?></label>
-		<input id="last_name" name="last_name" type="text" class="input pmpro_required <?php echo pmpro_getClassForField( 'last_name' ); ?>" size="30" value="<?php echo esc_attr( $last_name ); ?>" />
+		<input id="last_name" name="last_name" type="text" class="input <?php echo $last_name_required ? esc_attr( 'pmpro_required' ) : ''; ?> <?php echo pmpro_getClassForField( 'last_name' ); ?>" size="30" value="<?php echo esc_attr( $last_name ); ?>" />
 	</div> 
 	<?php
 }
@@ -73,9 +91,24 @@ add_action( 'pmpro_checkout_after_pricing_fields', 'pmproan2c_account_info_when_
 
 /**
  * Require the fields.
+ *
+ * @return bool `true` if registration check passed, `false` if not.
  */
 function pmproan2c_pmpro_registration_checks() {
 	global $pmpro_msg, $pmpro_msgt, $current_user, $pmpro_error_fields;
+
+	$pmproan2c_error_fields  = array();
+	$pmproan2c_error_message = '';
+	$pmproan2c_errors        = false;
+
+	/**
+	 * Filter whether first/last names are required fields.
+	 *
+	 * @see pmproan2c_pmpro_checkout_after_password for filter definitions.
+	 */
+	$first_name_required = apply_filters( 'pmproan2c_first_name_required', true );
+	$last_name_required  = apply_filters( 'pmproan2c_last_name_required', true );
+
 	if ( ! empty( $_REQUEST['first_name'] ) ) {
 		$first_name = trim( sanitize_text_field( $_REQUEST['first_name'] ) );
 	} elseif ( ! empty( $_SESSION['first_name'] ) ) {
@@ -100,16 +133,33 @@ function pmproan2c_pmpro_registration_checks() {
 		//all good
 		return true;
 	} else {
-		$pmpro_msg  = __( 'The first and last name fields are required.', 'pmpro-add-name-to-checkout' );
-		$pmpro_msgt = 'pmpro_error';
-		if ( ! $first_name ) {
-			$pmpro_error_fields[] = 'first_name';
+		if ( $first_name_required && $last_name_required ) {
+			$pmproan2c_error_message = __( 'The first and last name fields are required.', 'pmpro-add-name-to-checkout' );
+		} elseif ( $first_name_required ) {
+			$pmproan2c_error_message = __( 'The first name field is required.', 'pmpro-add-name-to-checkout' );
+		} elseif ( $last_name_required ) {
+			$pmproan2c_error_message = __( 'The last name field is required.', 'pmpro-add-name-to-checkout' );
 		}
-		if ( ! $last_name ) {
-			$pmpro_error_fields[] = 'last_name';
+
+		if ( ! $first_name && $first_name_required ) {
+			$pmproan2c_error_fields[] = 'first_name';
 		}
-		return false;
+		if ( ! $last_name && $last_name_required ) {
+			$pmproan2c_error_fields[] = 'last_name';
+		}
 	}
+	if ( empty( $pmproan2c_error_fields ) ) {
+		return true;
+	} else {
+		$pmproan2c_errors = true;
+	}
+	// Populate globals.
+	if ( $pmproan2c_errors ) {
+		$pmpro_msgt = 'pmpro_error';
+		$pmpro_msg  = $pmproan2c_error_message;
+	}
+	$pmpro_error_fields = array_merge( $pmpro_error_fields, $pmproan2c_error_fields );
+	return false;
 }
 add_filter( 'pmpro_registration_checks', 'pmproan2c_pmpro_registration_checks' );
 


### PR DESCRIPTION
This PR adds two filters:

- `pmproan2c_first_name_required`
- `pmproan2c_last_name_required`

Both take booleans. `true` is default.

An example of the filters in use:

```php
add_filter( 'pmproan2c_first_name_required', '__return_false' );
add_filter( 'pmproan2c_last_name_required', '__return_false' );
```

The following scenarios have been tested:

1. Checkout with just first name required (for each filter combination)
2. Checkout with just last name required (for each filter combination)
3. Checkout with both first and last name required (for each filter combination)

Function variables are used at first instead of globals so as to not populate the global namespace until we are sure there are errors to display.



