### PR TITLE
Localization tweak

### DIFF
--- a/pmpro-add-name-to-checkout.php
+++ b/pmpro-add-name-to-checkout.php
@@ -16,7 +16,7 @@ Author URI: http://www.strangerstudios.com
 function pmproan2c_load_textdomain() {
   load_plugin_textdomain( 'pmpro-add-name-to-checkout', false, plugin_basename( dirname( __FILE__ ) ) . '/languages' );
 }
-add_action( 'plugins_loaded', 'pmproan2c_load_textdomain' );
+add_action( 'init', 'pmproan2c_load_textdomain' );
 
 /**
  * Add the fields to the form.


### PR DESCRIPTION
Change load textdomain from `plugins_loaded` to `init` for better translation editor compatibility.