### PR TITLE
Saving data to post meta is no longer needed

### DIFF
--- a/pmpro-add-name-to-checkout.php
+++ b/pmpro-add-name-to-checkout.php
@@ -232,7 +232,6 @@ function pmproan2c_update_first_and_last_name_after_checkout( $user_id ) {
 	update_user_meta( $user_id, 'first_name', $first_name );
 	update_user_meta( $user_id, 'last_name', $last_name );
 	update_user_meta( $user_id, 'display_name', $first_name . ' ' . $last_name );
-	update_post_meta( $user_id, 'billing_name', $first_name . ' ' . $last_name );
 
 	// unset the user fields in session
 	unset( $_SESSION['first_name'] );


### PR DESCRIPTION
* BUG FIX: Remove erroneous call to update_post_meta for billing name for checkouts.

As of Paid Memberships Pro V2.7+ we have improved the customer name that is created or updated when purchasing with Stripe.

If you need to tweak the customer's name for Stripe hook into `pmpro_stripe_update_customer_at_checkout`

Resolves: https://github.com/strangerstudios/pmpro-add-name-to-checkout/issues/44